### PR TITLE
chore: unify pyproject.toml across repositories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,77 +75,79 @@ Tracker = "https://github.com/linuxfabrik/firewallfabrik/issues/"
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = { attr = "firewallfabrik.__version__" }
+version = { attr = 'firewallfabrik.__version__' }
 
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ['src']
 
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ['tests']
 
 
 # === linters ===
 [tool.pyright]
-exclude = ["src/firewallfabrik/gui", "venv"]
+exclude = ['src/firewallfabrik/gui', 'venv']
 
 [tool.ruff]
-target-version = "py311" # minimum supported Python
+line-length = 88
+target-version = 'py311' # minimum supported Python
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "F",    # pyflakes (logic errors)
-    "I",    # isort (import sorting)
-    "B",    # flake8-bugbear (potential bugs)
-    "C4",   # flake8-comprehensions
-    "UP",   # pyupgrade (modernize syntax)
-    "SIM",  # flake8-simplify
-    "TID",  # flake8-tidy-imports
-    "PTH",  # flake8-use-pathlib
-    "RUF",  # Ruff-specific rules
+    'B',    # flake8-bugbear (potential bugs)
+    'C4',   # flake8-comprehensions
+    'E',    # pycodestyle errors
+    'F',    # pyflakes (logic errors)
+    'I',    # isort (import sorting)
+    'PTH',  # flake8-use-pathlib
+    'RUF',  # Ruff-specific rules
+    'SIM',  # flake8-simplify
+    'TID',  # flake8-tidy-imports
+    'UP',   # pyupgrade (modernize syntax)
+    'W',    # pycodestyle warnings
 ]
 ignore = [
-    "E501",  # line too long
+    'E501',  # line too long
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["firewallfabrik"]
+known-first-party = ['firewallfabrik']
 
 [tool.ruff.lint.per-file-ignores]
 # SQLAlchemy models use forward-reference strings resolved at runtime (F821)
 # and require mutable class attributes like __mapper_args__ without ClassVar (RUF012)
-"src/firewallfabrik/core/objects/*.py" = ["F821", "RUF012"]
+'src/firewallfabrik/core/objects/*.py' = ['F821', 'RUF012']
 
 [tool.ruff.format]
-quote-style = "single"
+docstring-code-format = true
+quote-style = 'single'
 
 [tool.bandit]
 # B110 (try/except/pass) and B112 (try/except/continue): intentional patterns
 # for graceful degradation in a GUI/CLI tool.
 # B311 (pseudo-random): not used for cryptographic purposes.
-skips = ["B110", "B112", "B311"]
+skips = ['B110', 'B112', 'B311']
 
 [tool.bandit.assert_used]
-# pytest-style asserts are idiomatic in tests/, but bandit still scans the
-# directory for other real issues.
-skips = ["*/tests/*.py", "tests/*.py"]
+# pytest relies on the `assert` statement, so B101 does not apply under tests/.
+# bandit still scans the directory for every other finding.
+skips = ['*/tests/*.py', 'tests/*.py']
 
 [tool.vulture]
 min_confidence = 80
-paths = ["src/firewallfabrik"]
+paths = ['src/firewallfabrik']
 # GUI dialogs are excluded: PySide6 .ui-driven widgets have many attributes
 # accessed dynamically by Qt, which vulture cannot see.
-exclude = ["src/firewallfabrik/gui"]
+exclude = ['src/firewallfabrik/gui']
 # API-required parameters of framework override methods (SQLAlchemy
 # TypeDecorator / event listeners, yaml.SafeDumper override, base-class
 # compiler driver signatures). They are named positionally by the framework,
 # so we cannot rename them away, and they are part of the contract.
 ignore_names = [
-    "attached_networks",
-    "cluster_id",
-    "connection_record",
-    "dialect",
-    "indentless",
+    'attached_networks',
+    'cluster_id',
+    'connection_record',
+    'dialect',
+    'indentless',
 ]

--- a/src/firewallfabrik/platforms/_defaults.py
+++ b/src/firewallfabrik/platforms/_defaults.py
@@ -28,7 +28,7 @@ Example usage::
     )
 
     schema = get_platform_defaults('iptables')
-    seed   = get_default_values('iptables')
+    seed = get_default_values('iptables')
 """
 
 import functools


### PR DESCRIPTION
The lint configuration grew per repository in April 2026 instead of from a shared template, and firewallfabrik and mcp-server-icinga came from a different project skeleton. That left four dialects behind.

Unified: `line-length` is now stated explicitly as 88 everywhere (the ruff default; checklistfabrik was the outlier at 100), `[tool.ruff.format]` is byte-identical in all six repositories that run ruff, the `select` list is alphabetical, `[tool.bandit.assert_used]` uses one pattern, and strings inside `[tool.*]` are single-quoted. `[build-system]`, `[project]` and `[tool.setuptools]` are left alone: those are per-project and double quotes are the ecosystem norm there.

`target-version`, the `ignore` lists and the extra `PTH`/`TID` rules stay per repository, they follow from the codebase.